### PR TITLE
add import of aqt submodule

### DIFF
--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -19,6 +19,7 @@ import pytest
 import sympy
 
 import cirq_superstaq
+from cirq_superstaq import aqt
 
 
 def test_service_run() -> None:
@@ -95,7 +96,7 @@ def test_service_create_job() -> None:
 )
 def test_service_aqt_compile(mock_aqt_compile: mock.MagicMock) -> None:
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
-    expected = cirq_superstaq.aqt.AQTCompilerOutput(cirq.Circuit())
+    expected = aqt.AQTCompilerOutput(cirq.Circuit())
     assert service.aqt_compile(cirq.Circuit()) == expected
 
 


### PR DESCRIPTION


previously `$ check/pytest` and `$ pytest aqt_test.py service_test.py` both worked because aqt_test.py imports `cirq_superstaq.aqt`, but `$ pytest service_test.py` would fail because `cirq_superstaq.aqt.AQTCompilerOutput` was used before the `aqt` submodule was loaded