### PR TITLE
Support testing with qtrl

### DIFF
--- a/cirq_superstaq/aqt.py
+++ b/cirq_superstaq/aqt.py
@@ -1,4 +1,5 @@
 import codecs
+import importlib
 import pickle
 from dataclasses import dataclass
 from typing import Optional
@@ -6,7 +7,7 @@ from typing import Optional
 import cirq
 
 try:
-    import qtrl
+    import qtrl.sequencer
 except ModuleNotFoundError:
     pass
 
@@ -28,14 +29,13 @@ def read_json(json_dict: dict) -> AQTCompilerOutput:
     """
     compiled_circuit = cirq.read_json(json_text=json_dict["compiled_circuit"])
 
-    try:
-        import qtrl
-    except ModuleNotFoundError:
+    if not importlib.util.find_spec("qtrl"):
         return AQTCompilerOutput(compiled_circuit)
 
-    if True:  # pragma: no cover, b/c qtrl is not open source so it is not in cirq-superstaq reqs
+    else:  # pragma: no cover, b/c qtrl is not open source so it is not in cirq-superstaq reqs
         state_str = json_dict["state_jp"]
         state = pickle.loads(codecs.decode(state_str.encode(), "base64"))
+
         seq = qtrl.sequencer.Sequence(n_elements=1)
         seq.__setstate__(state)
         seq.compile()

--- a/cirq_superstaq/aqt_test.py
+++ b/cirq_superstaq/aqt_test.py
@@ -1,9 +1,46 @@
+import codecs
+import importlib
+import pickle
+from unittest import mock
+
 import cirq
+import pytest
 
 from cirq_superstaq import aqt
 
 
+@mock.patch.dict("sys.modules", {"qtrl": None})
 def test_read_json() -> None:
+    importlib.reload(aqt)
+
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(4)))
-    json_dict = {"compiled_circuit": cirq.to_json(circuit)}
-    assert aqt.read_json(json_dict) == aqt.AQTCompilerOutput(circuit)
+    state_str = codecs.encode(pickle.dumps({}), "base64").decode()
+    pulse_list_str = codecs.encode(pickle.dumps([]), "base64").decode()
+
+    json_dict = {
+        "compiled_circuit": cirq.to_json(circuit),
+        "state_jp": state_str,
+        "pulse_list_jp": pulse_list_str,
+    }
+    compiler_output = aqt.read_json(json_dict)
+
+    assert compiler_output == aqt.AQTCompilerOutput(circuit)
+
+
+def test_read_json_with_qtrl() -> None:  # pragma: no cover, b/c test requires qtrl installation
+    qtrl = pytest.importorskip("qtrl", reason="qtrl not installed")
+    seq = qtrl.sequencer.Sequence(n_elements=1)
+
+    circuit = cirq.Circuit(cirq.H(cirq.LineQubit(4)))
+    state_str = codecs.encode(pickle.dumps(seq.__getstate__()), "base64").decode()
+    pulse_list_str = codecs.encode(pickle.dumps([]), "base64").decode()
+
+    json_dict = {
+        "compiled_circuit": cirq.to_json(circuit),
+        "state_jp": state_str,
+        "pulse_list_jp": pulse_list_str,
+    }
+    compiler_output = aqt.read_json(json_dict)
+
+    assert compiler_output.circuit == circuit
+    assert pickle.dumps(compiler_output.seq) == pickle.dumps(seq)

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -11,7 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import codecs
 import os
+import pickle
 from unittest import mock
 
 import applications_superstaq
@@ -20,7 +22,6 @@ import pytest
 import sympy
 
 import cirq_superstaq
-from cirq_superstaq import aqt
 
 
 def test_service_run() -> None:
@@ -93,12 +94,16 @@ def test_service_create_job() -> None:
 
 @mock.patch(
     "cirq_superstaq.superstaq_client._SuperstaQClient.aqt_compile",
-    return_value={"compiled_circuit": cirq.to_json(cirq.Circuit())},
+    return_value={
+        "compiled_circuit": cirq.to_json(cirq.Circuit()),
+        "state_jp": codecs.encode(pickle.dumps({}), "base64").decode(),
+        "pulse_list_jp": codecs.encode(pickle.dumps([]), "base64").decode(),
+    },
 )
 def test_service_aqt_compile(mock_aqt_compile: mock.MagicMock) -> None:
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
-    expected = aqt.AQTCompilerOutput(cirq.Circuit())
-    assert service.aqt_compile(cirq.Circuit()) == expected
+    expected = cirq.Circuit()
+    assert service.aqt_compile(cirq.Circuit()).circuit == expected
 
 
 @mock.patch(


### PR DESCRIPTION
changes required to fix testing and test coverage when qtrl is available in the local environement:
* include "state_jp" and "pulse_list_jp" elements in json_dict passed to `aqt.read_json()` in all tests (aqt_test.py and service_test.py)
* mock qtrl unavailability in `aqt_test.test_read_json()` so that it always functions as if qtrl is not installed
* add `aqt_test.test_read_json_with_qtrl()` to check qtrl functionality (skipped when qtrl is not available)