### PR TITLE
clean up Barrier diagram

### DIFF
--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -200,6 +200,8 @@ class Barrier(cirq.ops.IdentityGate):
         return f"cirq_superstaq.custom_gates.Barrier({self.num_qubits()})"
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> Tuple[str, ...]:
+        if args.use_unicode_characters:
+            return ("│",) * self.num_qubits()
         return ("|",) * self.num_qubits()
 
 

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -130,12 +130,25 @@ barrier q[0],q[1],q[2];
     cirq.testing.assert_has_diagram(
         circuit,
         """
-0: ───|───
+0: ───│───
       │
-1: ───|───
+1: ───│───
       │
-2: ───|───
+2: ───│───
 """,
+        use_unicode_characters=True,
+    )
+
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ---|---
+      |
+1: ---|---
+      |
+2: ---|---
+""",
+        use_unicode_characters=False,
     )
 
 


### PR DESCRIPTION
(not pressing but has been bothering me)

changes Barrier diagram from:
```
0: ───|───
      │
1: ───|───
      │
2: ───|───
```
to:
```
0: ───│───
      │
1: ───│───
      │
2: ───│───
```