### PR TITLE
Serialization

### DIFF
--- a/cirq_superstaq/__init__.py
+++ b/cirq_superstaq/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from cirq_superstaq import serialization
 from cirq_superstaq._init_vars import API_URL, API_VERSION
 from cirq_superstaq.custom_gates import (
     AceCR,
@@ -44,6 +45,7 @@ __all__ = [
     "FermionicSWAPGate",
     "Job",
     "ParallelGates",
+    "serialization",
     "Service",
     "SuperstaQException",
     "SuperstaQModuleNotFoundException",

--- a/cirq_superstaq/aqt.py
+++ b/cirq_superstaq/aqt.py
@@ -1,8 +1,7 @@
-import codecs
 import importlib
-import pickle
 from typing import List, Optional, Union
 
+import applications_superstaq
 import cirq
 
 import cirq_superstaq
@@ -61,15 +60,13 @@ def read_json(json_dict: dict, circuits_list: bool) -> AQTCompilerOutput:
     if importlib.util.find_spec(
         "qtrl"
     ):  # pragma: no cover, b/c qtrl is not open source so it is not in cirq-superstaq reqs
-        state_str = json_dict["state_jp"]
-        state = pickle.loads(codecs.decode(state_str.encode(), "base64"))
+        state = applications_superstaq.converters.deserialize(json_dict["state_jp"])
 
         seq = qtrl.sequencer.Sequence(n_elements=1)
         seq.__setstate__(state)
         seq.compile()
 
-        pulse_lists_str = json_dict["pulse_lists_jp"]
-        pulse_lists = pickle.loads(codecs.decode(pulse_lists_str.encode(), "base64"))
+        pulse_lists = applications_superstaq.converters.deserialize(json_dict["pulse_lists_jp"])
 
     resolvers = [cirq_superstaq.custom_gates.custom_resolver, *cirq.DEFAULT_RESOLVERS]
     compiled_circuits = [

--- a/cirq_superstaq/aqt_test.py
+++ b/cirq_superstaq/aqt_test.py
@@ -1,8 +1,8 @@
-import codecs
 import importlib
 import pickle
 from unittest import mock
 
+import applications_superstaq
 import cirq
 import pytest
 
@@ -22,8 +22,8 @@ def test_read_json() -> None:
     importlib.reload(aqt)
 
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(4)))
-    state_str = codecs.encode(pickle.dumps({}), "base64").decode()
-    pulse_lists_str = codecs.encode(pickle.dumps([[[]]]), "base64").decode()
+    state_str = applications_superstaq.converters.serialize({})
+    pulse_lists_str = applications_superstaq.converters.serialize([[[]]])
 
     json_dict: dict
 
@@ -42,7 +42,7 @@ def test_read_json() -> None:
     assert not hasattr(out, "circuit")
 
     # multiple circuits
-    pulse_lists_str = codecs.encode(pickle.dumps([[[]], [[]]]), "base64").decode()
+    pulse_lists_str = applications_superstaq.converters.serialize([[[]], [[]]])
     json_dict = {
         "cirq_circuits": [cirq.to_json(circuit), cirq.to_json(circuit)],
         "state_jp": state_str,
@@ -58,8 +58,8 @@ def test_read_json_with_qtrl() -> None:  # pragma: no cover, b/c test requires q
     seq = qtrl.sequencer.Sequence(n_elements=1)
 
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(4)))
-    state_str = codecs.encode(pickle.dumps(seq.__getstate__()), "base64").decode()
-    pulse_lists_str = codecs.encode(pickle.dumps([[[]]]), "base64").decode()
+    state_str = applications_superstaq.converters.serialize(seq.__getstate__())
+    pulse_lists_str = applications_superstaq.converters.serialize([[[]]])
 
     json_dict: dict
 
@@ -82,7 +82,7 @@ def test_read_json_with_qtrl() -> None:  # pragma: no cover, b/c test requires q
     assert not hasattr(out, "circuit") and not hasattr(out, "pulse_list")
 
     # multiple circuits
-    pulse_lists_str = codecs.encode(pickle.dumps([[[]], [[]]]), "base64").decode()
+    pulse_lists_str = applications_superstaq.converters.serialize([[[]], [[]]])
     json_dict = {
         "cirq_circuits": [cirq.to_json(circuit), cirq.to_json(circuit)],
         "state_jp": state_str,

--- a/cirq_superstaq/serialization.py
+++ b/cirq_superstaq/serialization.py
@@ -1,0 +1,33 @@
+from typing import List, Union
+
+import cirq
+
+import cirq_superstaq
+
+
+def serialize_circuits(circuits: Union[cirq.Circuit, List[cirq.Circuit]]) -> str:
+    """Serialize Circuit(s) into a json string
+
+    Args:
+        circuits: a Circuit or list of Circuits to be serialized
+
+    Returns:
+        str representing the serialized circuit(s)
+    """
+    if isinstance(circuits, cirq.Circuit):
+        return cirq.to_json([circuits])
+
+    return cirq.to_json(circuits)
+
+
+def deserialize_circuits(serialized_circuits: str) -> Union[cirq.Circuit, List[cirq.Circuit]]:
+    """Deserialize serialized Circuit(s)
+
+    Args:
+        serialized_circuits: json str generated via converters.serialize_circuit()
+
+    Returns:
+        the Circuit or list of Circuits that was serialized
+    """
+    resolvers = [cirq_superstaq.custom_gates.custom_resolver, *cirq.DEFAULT_RESOLVERS]
+    return cirq.read_json(json_text=serialized_circuits, resolvers=resolvers)

--- a/cirq_superstaq/serialization.py
+++ b/cirq_superstaq/serialization.py
@@ -14,9 +14,6 @@ def serialize_circuits(circuits: Union[cirq.Circuit, List[cirq.Circuit]]) -> str
     Returns:
         str representing the serialized circuit(s)
     """
-    if isinstance(circuits, cirq.Circuit):
-        return cirq.to_json([circuits])
-
     return cirq.to_json(circuits)
 
 

--- a/cirq_superstaq/serialization_test.py
+++ b/cirq_superstaq/serialization_test.py
@@ -1,0 +1,17 @@
+import cirq
+
+import cirq_superstaq.serialization
+
+
+def test_serialization() -> None:
+    qubits = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.CX(*qubits), cirq_superstaq.ZX(*qubits))
+
+    serialized_circuit = cirq_superstaq.serialization.serialize_circuits(circuit)
+    assert isinstance(serialized_circuit, str)
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == [circuit]
+
+    circuits = [circuit, circuit]
+    serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)
+    assert isinstance(serialized_circuits, str)
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuits) == circuits

--- a/cirq_superstaq/serialization_test.py
+++ b/cirq_superstaq/serialization_test.py
@@ -9,7 +9,7 @@ def test_serialization() -> None:
 
     serialized_circuit = cirq_superstaq.serialization.serialize_circuits(circuit)
     assert isinstance(serialized_circuit, str)
-    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == [circuit]
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == circuit
 
     circuits = [circuit, circuit]
     serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)

--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -216,7 +216,7 @@ class Service:
         Raises:
             SuperstaQException: If there was an error accessing the API.
         """
-        serialized_program = cirq.to_json(circuit)
+        serialized_program = cirq_superstaq.serialization.serialize_circuits(circuit)
         result = self._client.create_job(
             serialized_program=serialized_program, repetitions=repetitions, target=target, name=name
         )
@@ -271,10 +271,10 @@ class Service:
             .pulse_list(s) attribute is the list(s) of cycles.
         """
         if isinstance(circuits, cirq.Circuit):
-            serialized_program = cirq.to_json([circuits])
+            serialized_program = cirq_superstaq.serialization.serialize_circuits([circuits])
             circuits_list = False
         else:
-            serialized_program = cirq.to_json(circuits)
+            serialized_program = cirq_superstaq.serialization.serialize_circuits(circuits)
             circuits_list = True
 
         json_dict = self._client.aqt_compile(serialized_program)
@@ -288,7 +288,7 @@ class Service:
 
         Qiskit must be installed for returned object to correctly deserialize to a pulse schedule.
         """
-        serialized_program = cirq.to_json([circuit])
+        serialized_program = cirq_superstaq.serialization.serialize_circuits([circuit])
         json_dict = self._client.ibmq_compile(serialized_program, target)
         try:
             return applications_superstaq.converters.deserialize(json_dict["pulses"])[0]

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -11,10 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import codecs
 import collections
 import os
-import pickle
 from unittest import mock
 
 import applications_superstaq
@@ -144,8 +142,8 @@ def test_service_get_balance() -> None:
     "cirq_superstaq.superstaq_client._SuperstaQClient.aqt_compile",
     return_value={
         "cirq_circuits": [cirq.to_json(cirq.Circuit())],
-        "state_jp": codecs.encode(pickle.dumps({}), "base64").decode(),
-        "pulse_lists_jp": codecs.encode(pickle.dumps([[[]]]), "base64").decode(),
+        "state_jp": applications_superstaq.converters.serialize({}),
+        "pulse_lists_jp": applications_superstaq.converters.serialize([[[]]]),
     },
 )
 def test_service_aqt_compile_single(mock_aqt_compile: mock.MagicMock) -> None:
@@ -159,8 +157,8 @@ def test_service_aqt_compile_single(mock_aqt_compile: mock.MagicMock) -> None:
     "cirq_superstaq.superstaq_client._SuperstaQClient.aqt_compile",
     return_value={
         "cirq_circuits": [cirq.to_json(cirq.Circuit()), cirq.to_json(cirq.Circuit())],
-        "state_jp": codecs.encode(pickle.dumps({}), "base64").decode(),
-        "pulse_lists_jp": codecs.encode(pickle.dumps([[[]], [[]]]), "base64").decode(),
+        "state_jp": applications_superstaq.converters.serialize({}),
+        "pulse_lists_jp": applications_superstaq.converters.serialize([[[]], [[]]]),
     },
 )
 def test_service_aqt_compile_multiple(mock_aqt_compile: mock.MagicMock) -> None:
@@ -188,13 +186,12 @@ def test_service_ibmq_compile(mock_ibmq_compile: mock.MagicMock) -> None:
 @mock.patch(
     "cirq_superstaq.superstaq_client._SuperstaQClient.submit_qubo",
     return_value={
-        "solution": codecs.encode(
+        "solution": applications_superstaq.converters.serialize(
             np.rec.array(
                 [({0: 0, 1: 1, 3: 1}, -1, 6), ({0: 1, 1: 1, 3: 1}, -1, 4)],
                 dtype=[("solution", "O"), ("energy", "<f8"), ("num_occurrences", "<i8")],
-            ).dumps(),
-            "base64",
-        ).decode()
+            )
+        )
     },
 )
 def test_service_submit_qubo(mock_submit_qubo: mock.MagicMock) -> None:

--- a/cirq_superstaq/superstaq_client_test.py
+++ b/cirq_superstaq/superstaq_client_test.py
@@ -338,7 +338,7 @@ def test_superstaq_client_aqt_compile(mock_post: mock.MagicMock) -> None:
         remote_host="http://example.com", api_key="to_my_heart", default_target="simulator"
     )
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(5)))
-    client.aqt_compile(cirq.to_json([circuit, circuit]))
+    client.aqt_compile(cirq_superstaq.serialization.serialize_circuits([circuit, circuit]))
 
     mock_post.assert_called_once()
     assert mock_post.call_args[0][0] == f"http://example.com/{API_VERSION}/aqt_compile"
@@ -350,7 +350,7 @@ def test_superstaq_client_ibmq_compile(mock_post: mock.MagicMock) -> None:
         remote_host="http://example.com", api_key="to_my_heart", default_target="simulator"
     )
     circuit = cirq.Circuit()
-    client.ibmq_compile(cirq.to_json([circuit]))
+    client.ibmq_compile(cirq_superstaq.serialization.serialize_circuits([circuit]))
 
     mock_post.assert_called_once()
     assert mock_post.call_args[0][0] == f"http://example.com/{API_VERSION}/ibmq_compile"


### PR DESCRIPTION
* add `serialization.(de)serialize_circuits()` functions in anticipation of `v03` API
* use `applications_superstaq.converters.(de)serialize()` wherever possible