### PR TITLE
Deserialize circuits to always return a list

### DIFF
--- a/cirq_superstaq/aqt.py
+++ b/cirq_superstaq/aqt.py
@@ -68,9 +68,8 @@ def read_json(json_dict: dict, circuits_list: bool) -> AQTCompilerOutput:
 
         pulse_lists = applications_superstaq.converters.deserialize(json_dict["pulse_lists_jp"])
 
-    resolvers = [cirq_superstaq.custom_gates.custom_resolver, *cirq.DEFAULT_RESOLVERS]
     compiled_circuits = [
-        cirq.read_json(json_text=c, resolvers=resolvers) for c in json_dict["cirq_circuits"]
+        cirq_superstaq.serialization.deserialize_circuits(c)[0] for c in json_dict["cirq_circuits"]
     ]
     if circuits_list:
         return AQTCompilerOutput(compiled_circuits, seq, pulse_lists)

--- a/cirq_superstaq/serialization.py
+++ b/cirq_superstaq/serialization.py
@@ -17,7 +17,7 @@ def serialize_circuits(circuits: Union[cirq.Circuit, List[cirq.Circuit]]) -> str
     return cirq.to_json(circuits)
 
 
-def deserialize_circuits(serialized_circuits: str) -> Union[cirq.Circuit, List[cirq.Circuit]]:
+def deserialize_circuits(serialized_circuits: str) -> List[cirq.Circuit]:
     """Deserialize serialized Circuit(s)
 
     Args:
@@ -27,4 +27,7 @@ def deserialize_circuits(serialized_circuits: str) -> Union[cirq.Circuit, List[c
         the Circuit or list of Circuits that was serialized
     """
     resolvers = [cirq_superstaq.custom_gates.custom_resolver, *cirq.DEFAULT_RESOLVERS]
-    return cirq.read_json(json_text=serialized_circuits, resolvers=resolvers)
+    circuits = cirq.read_json(json_text=serialized_circuits, resolvers=resolvers)
+    if isinstance(circuits, cirq.Circuit):
+        return [circuits]
+    return circuits

--- a/cirq_superstaq/serialization_test.py
+++ b/cirq_superstaq/serialization_test.py
@@ -9,7 +9,7 @@ def test_serialization() -> None:
 
     serialized_circuit = cirq_superstaq.serialization.serialize_circuits(circuit)
     assert isinstance(serialized_circuit, str)
-    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == circuit
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == [circuit]
 
     circuits = [circuit, circuit]
     serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)


### PR DESCRIPTION
this makes it symmetric with `qiskit_superstaq.serialization.deserialize_circuits()` (which uses `qpy_serialization.load()` which always returns a list of circuits). It also simplifies type checking a bit