### PR TITLE
fixed test to check for all backends regardless of ordering

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -65,9 +65,14 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_advantage-system1.1_qpu",
             "ionq_ion_qpu",
         ],
-        "compile-only": ["aqt_keysight_qpu", "sandia_qscout_qpu"],
+        "compile-only": [
+            "aqt_keysight_qpu",
+            "sandia_qscout_qpu",
+        ],
     }
-    assert service.get_backends() == expected
+    result = service.get_backends()
+    assert set(result["compile-and-run"]) == set(expected["compile-and-run"])
+    assert set(result["compile-only"]) == set(expected["compile-only"])
 
 
 def test_qscout_compile(service: cirq_superstaq.Service) -> None:

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -65,10 +65,7 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_advantage-system1.1_qpu",
             "ionq_ion_qpu",
         ],
-        "compile-only": [
-            "aqt_keysight_qpu",
-            "sandia_qscout_qpu",
-        ],
+        "compile-only": ["aqt_keysight_qpu", "sandia_qscout_qpu"],
     }
     result = service.get_backends()
     assert set(result["compile-and-run"]) == set(expected["compile-and-run"])

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -68,8 +68,8 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
         "compile-only": ["aqt_keysight_qpu", "sandia_qscout_qpu"],
     }
     result = service.get_backends()
-    assert set(result["compile-and-run"]) == set(expected["compile-and-run"])
-    assert set(result["compile-only"]) == set(expected["compile-only"])
+    assert sorted(result["compile-and-run"]) == sorted(expected["compile-and-run"])
+    assert sorted(result["compile-only"]) == sorted(expected["compile-only"])
 
 
 def test_qscout_compile(service: cirq_superstaq.Service) -> None:


### PR DESCRIPTION
Changed test to check for all backend strings (ordering is irrelevant). Fixes #63.

![daily-integration-success](https://user-images.githubusercontent.com/18367737/139940686-07b90a5b-0a0f-4b36-8c6b-0fd9e25e5072.png)