### PR TITLE
Updates integration test to reflect current device statuses

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -61,8 +61,6 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_advantage-system4.1_qpu",
             "d-wave_dw-2000q-6_qpu",
             "aws_tn1_simulator",
-            "rigetti_aspen-9_qpu",
-            "d-wave_advantage-system1.1_qpu",
             "ionq_ion_qpu",
         ],
         "compile-only": ["aqt_keysight_qpu", "sandia_qscout_qpu"],


### PR DESCRIPTION
D-wave device `d-wave_advantage-system1.1_qpu` retired, Rigetti device `rigetti_aspen-9_qpu` offline. Fixes #112.

![update_devices_integration](https://user-images.githubusercontent.com/18367737/140539082-e94cc3dc-d46a-41a3-a15d-91e49c0e291c.png)