### PR TITLE
Updates `finance` notebook for new deployment

### DIFF
--- a/examples/finance.ipynb
+++ b/examples/finance.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "from cirq_superstaq import Service\n",
     "service = Service(\n",
-    "    api_key=\"\"\"Insert superstaq token that you received from https://superstaq.super.tech\"\"\",\n",
+    "    api_key=\"\"\"Insert superstaq token that you received from https://superstaq.super.tech\"\"\"\n",
     ")"
    ]
   },
@@ -72,9 +72,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "casablanca_job = service.create_job(circuit, repetitions=100, target=\"ibmq_casablanca\")\n",
-    "ionq_job = service.create_job(circuit, repetitions=100, target=\"ionq_ion\")\n",
-    "rigetti_job = service.create_job(circuit, repetitions=100, target=\"rigetti_aspen\")\n",
+    "jakarta_job = service.create_job(circuit, repetitions=100, target=\"ibmq_jakarta_qpu\")\n",
+    "ionq_job = service.create_job(circuit, repetitions=100, target=\"ionq_ion_qpu\")\n",
     "ibmq_qasm_job = service.create_job(circuit, repetitions=100, target=\"ibmq_qasm_simulator\")\n",
     "aws_sv1_job = service.create_job(circuit, repetitions=100, target=\"aws_sv1_simulator\")"
    ]
@@ -101,8 +100,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jobs = [casablanca_job, ionq_job, rigetti_job, ibmq_qasm_job, aws_sv1_job]\n",
-    "names = \"IBM-Casablanca\", \"IonQ\", \"Rigetti\", \"IBM-Sim\", \"AWS-Sim\"\n",
+    "jobs = [jakarta_job, ionq_job, ibmq_qasm_job, aws_sv1_job]\n",
+    "names = \"IBM-Jakarta\", \"IonQ\", \"IBM-Sim\", \"AWS-Sim\"\n",
     "for job, name in zip(jobs, names):\n",
     "    print(\"\\n\", name, \":\", job.status())\n",
     "    if job.status() == \"Done\":\n",
@@ -214,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/examples/finance.ipynb
+++ b/examples/finance.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "from cirq_superstaq import Service\n",
     "service = Service(\n",
-    "    api_key=\"\"\"Insert superstaq token that you received from https://superstaq.super.tech\"\"\"\n",
+    "    api_key=\"\"\"Insert superstaq token that you received from https://superstaq.super.tech\"\"\",\n",
     ")"
    ]
   },
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- changed IBM Q device to `jakarta`
- removed the retired / offline `rigetti` device
- fixed backend names to fit new format
![finance-fix-00](https://user-images.githubusercontent.com/18367737/141007609-a4e1136a-b3e4-407b-95c0-9d712c878672.png)
![finance-update-01](https://user-images.githubusercontent.com/18367737/141007618-9139ee71-80fc-4f6c-b120-3d896d68a83e.png)

