### PR TITLE
Changed d-wave backend

### DIFF
--- a/examples/finance.ipynb
+++ b/examples/finance.ipynb
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/examples/finance.ipynb
+++ b/examples/finance.ipynb
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = service.submit_qubo(qubo, target=\"dwave_2000\", repetitions=10000)"
+    "result = service.submit_qubo(qubo, target=\"d-wave_dw-2000q-6_qpu\", repetitions=10000)"
    ]
   },
   {
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed backend name for QUBO.
![qubo-backebnd](https://user-images.githubusercontent.com/18367737/141010638-08bd1e0e-ecf5-44ac-8760-7d926dd89764.png)

