### PR TITLE
Updated compile-only devices

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -63,7 +63,12 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "aws_tn1_simulator",
             "ionq_ion_qpu",
         ],
-        "compile-only": ["aqt_keysight_qpu", "sandia_qscout_qpu"],
+        "compile-only": [
+            "aqt_keysight_qpu",
+            "sandia_qscout_qpu",
+            "hqs_lt-s1-apival_qpu",
+            "hqs_lt-s1_qpu",
+        ],
     }
     result = service.get_backends()
     assert sorted(result["compile-and-run"]) == sorted(expected["compile-and-run"])


### PR DESCRIPTION
To match deployed version of `GetBackends` endpoint.

As verbalized by @vtomole, the test is indeed showing us the kind of errors we want it to (devices are not taken offline as often as was feared, which would cause the test to fail each time).

Somewhat tangentially related: perhaps it's a good idea to include in the docs standard requirements for deployment? (If that's something we can standardize.)