### PR TITLE
Checking devices accessible to Super.tech users in `daily_integration`

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -66,7 +66,6 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "sandia_qscout_qpu",
             "hqs_lt-s1-apival_qpu",
             "hqs_lt-s1_qpu",
-            "neutral_atom_qpu",
         ],
         "compile-only": [
             "aqt_keysight_qpu",

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -68,6 +68,7 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "sandia_qscout_qpu",
             "hqs_lt-s1-apival_qpu",
             "hqs_lt-s1_qpu",
+            "neutral_atom_qpu",
         ],
     }
     result = service.get_backends()

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -62,17 +62,12 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_dw-2000q-6_qpu",
             "aws_tn1_simulator",
             "ionq_ion_qpu",
-            "aqt_keysight_qpu",
-            "sandia_qscout_qpu",
-            "hqs_lt-s1-apival_qpu",
-            "hqs_lt-s1_qpu",
         ],
         "compile-only": [
             "aqt_keysight_qpu",
             "sandia_qscout_qpu",
             "hqs_lt-s1-apival_qpu",
             "hqs_lt-s1_qpu",
-            "neutral_atom_qpu",
         ],
     }
     result = service.get_backends()

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -66,7 +66,7 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "sandia_qscout_qpu",
             "hqs_lt-s1-apival_qpu",
             "hqs_lt-s1_qpu",
-            "neutral_atom_qpu"
+            "neutral_atom_qpu",
         ],
         "compile-only": [
             "aqt_keysight_qpu",

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -42,41 +42,9 @@ def test_tsp(service: cirq_superstaq.Service) -> None:
 
 
 def test_get_backends(service: cirq_superstaq.Service) -> None:
-    expected = {
-        "compile-and-run": [
-            "ibmq_qasm_simulator",
-            "ibmq_armonk_qpu",
-            "ibmq_santiago_qpu",
-            "ibmq_bogota_qpu",
-            "ibmq_lima_qpu",
-            "ibmq_belem_qpu",
-            "ibmq_quito_qpu",
-            "ibmq_statevector_simulator",
-            "ibmq_mps_simulator",
-            "ibmq_extended-stabilizer_simulator",
-            "ibmq_stabilizer_simulator",
-            "ibmq_manila_qpu",
-            "aws_dm1_simulator",
-            "aws_sv1_simulator",
-            "d-wave_advantage-system4.1_qpu",
-            "d-wave_dw-2000q-6_qpu",
-            "aws_tn1_simulator",
-            "ionq_ion_qpu",
-            "aqt_keysight_qpu",
-            "sandia_qscout_qpu",
-            "hqs_lt-s1-apival_qpu",
-            "hqs_lt-s1_qpu",
-        ],
-        "compile-only": [
-            "aqt_keysight_qpu",
-            "sandia_qscout_qpu",
-            "hqs_lt-s1-apival_qpu",
-            "hqs_lt-s1_qpu",
-        ],
-    }
     result = service.get_backends()
-    assert sorted(result["compile-and-run"]) == sorted(expected["compile-and-run"])
-    assert sorted(result["compile-only"]) == sorted(expected["compile-only"])
+    assert "ibmq_qasm_simulator" in result["compile-and-run"]
+    assert "aqt_keysight_qpu" in result["compile-only"]
 
 
 def test_qscout_compile(service: cirq_superstaq.Service) -> None:

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -62,6 +62,10 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_dw-2000q-6_qpu",
             "aws_tn1_simulator",
             "ionq_ion_qpu",
+            "aqt_keysight_qpu",
+            "sandia_qscout_qpu",
+            "hqs_lt-s1-apival_qpu",
+            "hqs_lt-s1_qpu",
         ],
         "compile-only": [
             "aqt_keysight_qpu",

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -62,6 +62,11 @@ def test_get_backends(service: cirq_superstaq.Service) -> None:
             "d-wave_dw-2000q-6_qpu",
             "aws_tn1_simulator",
             "ionq_ion_qpu",
+            "aqt_keysight_qpu",
+            "sandia_qscout_qpu",
+            "hqs_lt-s1-apival_qpu",
+            "hqs_lt-s1_qpu",
+            "neutral_atom_qpu"
         ],
         "compile-only": [
             "aqt_keysight_qpu",


### PR DESCRIPTION
Matching backends returned for test user to `daily_integration` test.

Moved https://github.com/SupertechLabs/cirq-superstaq/pull/127 to this -- error turned out not to be a problem with `neutral_atom_qpu`, as those changes (https://github.com/SupertechLabs/SuperstaQ/pull/917#issuecomment-972362675) are not yet merged.

![backend-daily-success](https://user-images.githubusercontent.com/18367737/142472437-c094edc3-59c4-477d-b269-070cae4df7c0.png)
