### PR TITLE
Added check for an `ibmq_token`

### DIFF
--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -220,12 +220,11 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
         Raises:
             SuperstaQException: If there was an error accessing the API.
         """
-        if target:
-            if "ibmq" in target and not self.ibmq_token:
-                raise EnvironmentError(
-                    "Parameter ibmq_token was not specified and the environment variable IBMQ_TOKEN"
-                    "was also not set."
-                )
+        if target and "ibmq" in target and not self.ibmq_token:
+            raise EnvironmentError(
+                "Parameter ibmq_token was not specified and the environment variable IBMQ_TOKEN was"
+                "also not set."
+            )
         serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuit)
         result = self._client.create_job(
             serialized_circuits={"cirq_circuits": serialized_circuits},

--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -89,6 +89,7 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
         self,
         remote_host: Optional[str] = None,
         api_key: Optional[str] = None,
+        ibmq_token: Optional[str] = None,
         default_target: str = None,
         api_version: str = cirq_superstaq.API_VERSION,
         max_retry_seconds: int = 3600,
@@ -126,6 +127,7 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
                 "Parameter api_key was not specified and the environment variable "
                 "SUPERSTAQ_API_KEY was also not set."
             )
+        self.ibmq_token = ibmq_token or os.getenv("IBMQ_TOKEN")
         self._client = superstaq_client._SuperstaQClient(
             client_name="cirq-superstaq",
             remote_host=self.remote_host,
@@ -218,6 +220,12 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
         Raises:
             SuperstaQException: If there was an error accessing the API.
         """
+        if target:
+            if "ibmq" in target and not self.ibmq_token:
+                raise EnvironmentError(
+                    "Parameter ibmq_token was not specified and the environment variable IBMQ_TOKEN"
+                    "was also not set."
+                )
         serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuit)
         result = self._client.create_job(
             serialized_circuits={"cirq_circuits": serialized_circuits},

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -52,7 +52,9 @@ def test_counts_to_results() -> None:
 
 
 def test_service_run_and_get_counts() -> None:
-    service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
+    service = cirq_superstaq.Service(
+        remote_host="http://example.com", api_key="key", ibmq_token="token"
+    )
     mock_client = mock.MagicMock()
     mock_client.create_job.return_value = {
         "job_ids": ["job_id"],
@@ -101,7 +103,9 @@ def test_service_run_and_get_counts() -> None:
 
 
 def test_service_sampler() -> None:
-    service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
+    service = cirq_superstaq.Service(
+        remote_host="http://example.com", api_key="key", ibmq_token="token"
+    )
     mock_client = mock.MagicMock()
     service._client = mock_client
     mock_client.create_job.return_value = {
@@ -159,6 +163,14 @@ def test_service_create_job() -> None:
     # Serialization induces a float, so we don't validate full circuit.
     assert create_job_kwargs["repetitions"] == 100
     assert create_job_kwargs["target"] == "qpu"
+
+
+def test_service_create_job_no_ibmq_token() -> None:
+    service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
+
+    circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
+    with pytest.raises(EnvironmentError):
+        _ = service.create_job(circuit=circuit, repetitions=100, target="ibmq_qpu")
 
 
 def test_service_get_balance() -> None:

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -165,10 +165,9 @@ def test_service_create_job() -> None:
     assert create_job_kwargs["target"] == "qpu"
 
 
+@mock.patch.dict(os.environ, {"IBMQ_TOKEN": ""})
 def test_service_create_job_no_ibmq_token() -> None:
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
-    with mock.patch.dict("os.environ"):
-        del os.environ["IBMQ_TOKEN"]
 
     circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
     with pytest.raises(EnvironmentError):

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -167,6 +167,8 @@ def test_service_create_job() -> None:
 
 def test_service_create_job_no_ibmq_token() -> None:
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
+    with mock.patch.dict("os.environ"):
+        del os.environ["IBMQ_TOKEN"]
 
     circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
     with pytest.raises(EnvironmentError):

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -170,7 +170,7 @@ def test_service_create_job_no_ibmq_token() -> None:
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
 
     circuit = cirq.Circuit(cirq.X(cirq.LineQubit(0)))
-    with pytest.raises(EnvironmentError):
+    with pytest.raises(EnvironmentError, match="Parameter ibmq_token was not specified"):
         _ = service.create_job(circuit=circuit, repetitions=100, target="ibmq_qpu")
 
 


### PR DESCRIPTION
Requires an `ibmq_token` for IBM Q targets. Fixes #119.

This only checks for the token in `create_job`, making token parameter itself in `Service` optional so that clients can run on non-IBM Q devices without needing an IBM Q token. 