### PR TITLE
Updates `jupyter` notebook demo to include `ibmq_token` parameter in `Service`

### DIFF
--- a/examples/finance.ipynb
+++ b/examples/finance.ipynb
@@ -17,7 +17,8 @@
    "source": [
     "from cirq_superstaq import Service\n",
     "service = Service(\n",
-    "    api_key=\"Insert superstaq token that you received from https://superstaq.super.tech\",\n",
+    "    api_key=\"Insert superstaq token that you received from https://superstaq.super.tech.\",\n",
+    "    ibmq_token=\"Insert IBM Q token that you received from https://quantum-computing.ibm.com/.\"\n",
     ")"
    ]
   },
@@ -25,7 +26,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f13ac60d-5e5f-400c-bc03-6f52fd0242a9",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "service.get_balance()"
@@ -213,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/examples/qscout_compile.ipynb
+++ b/examples/qscout_compile.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "029917c7-091c-4563-98b2-b1bf4d532660",
    "metadata": {},
    "outputs": [],
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "c80cdc6b",
    "metadata": {},
    "outputs": [],
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "5f107c0d-426e-4444-9749-8589bea4b679",
    "metadata": {
     "scrolled": true
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "86a9c7c0-81b8-438b-8f53-538dfa5b011d",
    "metadata": {},
    "outputs": [
@@ -77,26 +77,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "eabb48bb-7e06-42e2-acb8-70dc1209e591",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/vtomole/venv8/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "compiler_output = service.qscout_compile(circuit1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "fea5332a",
    "metadata": {},
    "outputs": [
@@ -116,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9d0937a8",
    "metadata": {},
    "outputs": [
@@ -153,26 +144,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "8fd1e2a6-4e63-470a-aaec-d9ccc432eb64",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/vtomole/venv8/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "compiler_output = service.qscout_compile([circuit, circuit1])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "5dcd7951",
    "metadata": {},
    "outputs": [
@@ -196,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "1ec75a40-ee18-4bee-b544-8bb1cbbbe45a",
    "metadata": {},
    "outputs": [
@@ -220,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "81e69456",
    "metadata": {},
    "outputs": [
@@ -250,7 +232,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -264,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
To match changes in https://github.com/SupertechLabs/cirq-superstaq/pull/133, adds token parameter to jupyter notebook demo `Service` object.

(Also some clean-up, removed output warnings from `qscout_compile.ipynb`)

![token-given](https://user-images.githubusercontent.com/18367737/145647120-4ceb0572-3eb1-46a1-9eea-9615d5e4fc88.png)

