### PR TITLE
add __pow__ method to ParallelRxy gate class

### DIFF
--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -469,6 +469,9 @@ class ParallelRxy(cirq.ParallelGate, cirq.InterchangeableQubitsGate):
     def rot_angle(self) -> float:
         return self.sub_gate.rot_angle
 
+    def __pow__(self, power: float) -> "ParallelRxy":
+        return ParallelRxy(self.axis_angle, power * self.rot_angle, self.num_copies)
+
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         diagram_info = cirq.circuit_diagram_info(self.sub_gate, args)
         wire_symbols = tuple(diagram_info.wire_symbols) + tuple(

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -376,6 +376,9 @@ def test_parallel_rxy() -> None:
     cirq.testing.assert_equivalent_repr(rot_gate, setup_code="import cirq; import cirq_superstaq")
     text = f"Rxy({rot_gate.phase_exponent}π, {rot_gate.exponent}π) x {len(qubits)}"
     assert str(rot_gate) == text
+    assert rot_gate ** -1 == cirq_superstaq.ParallelRxy(
+        rot_gate.axis_angle, -rot_gate.rot_angle, len(qubits)
+    )
 
     circuit = cirq.Circuit(rot_gate.on(*qubits))
 


### PR DESCRIPTION
... so that if `type(gate) is ParallelRxy`, then `type(gate ** power) is ParallelRxy`, which was not previously the case (and led to a bug in the CQDevice demo).