### PR TITLE
Changed "IBM Q" to "IBMQ", to match expected string

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -52,7 +52,7 @@ def test_ibmq_set_token() -> None:
     api_token = os.environ["TEST_USER_TOKEN"]
     ibmq_token = os.environ["TEST_USER_IBMQ_TOKEN"]
     service = cirq_superstaq.Service(api_key=api_token)
-    assert service.ibmq_set_token(ibmq_token) == "Your IBM Q account token has been updated"
+    assert service.ibmq_set_token(ibmq_token) == "Your IBMQ account token has been updated"
 
     with pytest.raises(SuperstaQException, match="IBMQ token is invalid."):
         assert service.ibmq_set_token("INVALID_TOKEN")


### PR DESCRIPTION
Fixes #165. Changed string to match service method return value.