### PR TITLE
FermionicSWAPGate -> ZZSwapGate

### DIFF
--- a/cirq_superstaq/__init__.py
+++ b/cirq_superstaq/__init__.py
@@ -20,12 +20,12 @@ from cirq_superstaq.custom_gates import (
     AceCRPlusMinus,
     Barrier,
     CR,
-    FermionicSWAPGate,
     ParallelGates,
     ParallelRGate,
     RGate,
     ZX,
     ZXPowGate,
+    ZZSwapGate,
 )
 from cirq_superstaq.job import Job
 from cirq_superstaq.sampler import Sampler
@@ -39,7 +39,6 @@ __all__ = [
     "API_VERSION",
     "Barrier",
     "CR",
-    "FermionicSWAPGate",
     "Job",
     "ParallelGates",
     "ParallelRGate",
@@ -49,4 +48,5 @@ __all__ = [
     "Service",
     "ZX",
     "ZXPowGate",
+    "ZZSwapGate",
 ]

--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -9,14 +9,14 @@ import cirq_superstaq
 
 
 @cirq.value_equality(approximate=True)
-class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsGate):
-    r"""The Fermionic SWAP gate, which performs the ZZ-interaction followed by a SWAP.
+class ZZSwapGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsGate):
+    r"""The ZZ-SWAP gate, which performs the ZZ-interaction followed by a SWAP.
 
-    Fermionic SWAPs are useful for applications like QAOA or Hamiltonian Simulation,
+    ZZ-SWAPs are useful for applications like QAOA or Hamiltonian Simulation,
     particularly on linear- or low- connectivity devices. See https://arxiv.org/pdf/2004.14970.pdf
-    for an application of Fermionic SWAP networks.
+    for an application of ZZ SWAP networks.
 
-    The unitary for a Fermionic SWAP gate parametrized by ZZ-interaction angle :math:`\theta` is:
+    The unitary for a ZZ-SWAP gate parametrized by ZZ-interaction angle :math:`\theta` is:
 
      .. math::
 
@@ -28,9 +28,7 @@ class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsG
         \end{bmatrix}
 
     where '.' means '0'.
-    For :math:`\theta = 0`, the Fermionic SWAP gate is just an ordinary SWAP.
-
-    Note that this gate is NOT the same as ``cirq.FSimGate``.
+    For :math:`\theta = 0`, the ZZ-SWAP gate is just an ordinary SWAP.
     """
 
     def __init__(self, theta: float) -> None:
@@ -60,16 +58,16 @@ class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsG
 
     def __pow__(
         self, exponent: float
-    ) -> Union["FermionicSWAPGate", cirq.type_workarounds.NotImplementedType]:
+    ) -> Union["ZZSwapGate", cirq.type_workarounds.NotImplementedType]:
         if exponent in (-1, 0, 1):
-            return FermionicSWAPGate(exponent * self.theta)
+            return ZZSwapGate(exponent * self.theta)
         return NotImplemented
 
     def __str__(self) -> str:
-        return f"FermionicSWAPGate({self.theta})"
+        return f"ZZSwapGate({self.theta})"
 
     def __repr__(self) -> str:
-        return f"cirq_superstaq.FermionicSWAPGate({self.theta})"
+        return f"cirq_superstaq.ZZSwapGate({self.theta})"
 
     def _decompose_(self, qubits: Tuple[cirq.Qid, cirq.Qid]) -> cirq.OP_TREE:
         yield cirq.CX(qubits[0], qubits[1])
@@ -79,7 +77,7 @@ class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsG
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         t = args.format_radians(self.theta)
-        return cirq.CircuitDiagramInfo(wire_symbols=(f"FermionicSWAP({t})", f"FermionicSWAP({t})"))
+        return cirq.CircuitDiagramInfo(wire_symbols=(f"ZZSwap({t})", f"ZZSwap({t})"))
 
     def _is_parameterized_(self) -> bool:
         return cirq.is_parameterized(self.theta)
@@ -87,10 +85,8 @@ class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsG
     def _parameter_names_(self) -> AbstractSet[str]:
         return cirq.parameter_names(self.theta)
 
-    def _resolve_parameters_(
-        self, resolver: cirq.ParamResolver, recursive: bool
-    ) -> "FermionicSWAPGate":
-        return FermionicSWAPGate(
+    def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> "ZZSwapGate":
+        return ZZSwapGate(
             cirq.protocols.resolve_parameters(self.theta, resolver, recursive),
         )
 
@@ -126,7 +122,7 @@ class FermionicSWAPGate(cirq.Gate, cirq.ops.gate_features.InterchangeableQubitsG
             return cirq.SWAP._qasm_(args, qubits)
 
         return args.format(
-            "fermionic_swap({0:half_turns}) {1},{2};\n",
+            "zzswap({0:half_turns}) {1},{2};\n",
             self.theta / np.pi,
             qubits[0],
             qubits[1],
@@ -496,8 +492,8 @@ class ParallelRGate(cirq.ParallelGate, cirq.InterchangeableQubitsGate):
 
 
 def custom_resolver(cirq_type: str) -> Union[Callable[..., cirq.Gate], None]:
-    if cirq_type == "FermionicSWAPGate":
-        return FermionicSWAPGate
+    if cirq_type == "ZZSwapGate":
+        return ZZSwapGate
     if cirq_type == "Barrier":
         return Barrier
     if cirq_type == "ZXPowGate":

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -9,12 +9,12 @@ import sympy
 import cirq_superstaq
 
 
-def test_fermionic_swap_gate() -> None:
+def test_zz_swap_gate() -> None:
     theta = 0.123
-    gate = cirq_superstaq.FermionicSWAPGate(theta)
+    gate = cirq_superstaq.ZZSwapGate(theta)
 
-    assert str(gate) == "FermionicSWAPGate(0.123)"
-    assert repr(gate) == "cirq_superstaq.FermionicSWAPGate(0.123)"
+    assert str(gate) == "ZZSwapGate(0.123)"
+    assert repr(gate) == "cirq_superstaq.ZZSwapGate(0.123)"
     cirq.testing.assert_equivalent_repr(gate, setup_code="import cirq_superstaq")
 
     expected = np.array(
@@ -37,23 +37,23 @@ def test_fermionic_swap_gate() -> None:
     cirq.testing.assert_pauli_expansion_is_consistent_with_unitary(gate)
 
     assert gate ** 1 == gate
-    assert gate ** 0 == cirq_superstaq.FermionicSWAPGate(0.0)
-    assert gate ** -1 == cirq_superstaq.FermionicSWAPGate(-0.123)
+    assert gate ** 0 == cirq_superstaq.ZZSwapGate(0.0)
+    assert gate ** -1 == cirq_superstaq.ZZSwapGate(-0.123)
 
     with pytest.raises(TypeError, match="unsupported operand type"):
         _ = gate ** 1.23
 
 
-def test_fermionic_swap_circuit() -> None:
+def test_zz_swap_circuit() -> None:
     qubits = cirq.LineQubit.range(3)
-    operation = cirq_superstaq.FermionicSWAPGate(0.456 * np.pi)(qubits[0], qubits[2])
+    operation = cirq_superstaq.ZZSwapGate(0.456 * np.pi)(qubits[0], qubits[2])
     circuit = cirq.Circuit(operation)
 
     expected_diagram = textwrap.dedent(
         """
-        0: ───FermionicSWAP(0.456π)───
+        0: ───ZZSwap(0.456π)───
               │
-        2: ───FermionicSWAP(0.456π)───
+        2: ───ZZSwap(0.456π)───
         """
     )
 
@@ -67,19 +67,19 @@ def test_fermionic_swap_circuit() -> None:
         qreg q[3];
 
 
-        fermionic_swap(pi*0.456) q[0],q[2];
+        zzswap(pi*0.456) q[0],q[2];
         """
     )
 
     cirq.testing.assert_has_diagram(circuit, expected_diagram)
     assert circuit.to_qasm(header="", qubit_order=qubits) == expected_qasm
 
-    circuit = cirq.Circuit(cirq_superstaq.FermionicSWAPGate(0.0)(qubits[0], qubits[1]))
+    circuit = cirq.Circuit(cirq_superstaq.ZZSwapGate(0.0)(qubits[0], qubits[1]))
     assert circuit.to_qasm() == cirq.Circuit(cirq.SWAP(qubits[0], qubits[1])).to_qasm()
 
 
-def test_fermionic_swap_parameterized() -> None:
-    gate = cirq_superstaq.FermionicSWAPGate(sympy.var("θ"))
+def test_zz_swap_parameterized() -> None:
+    gate = cirq_superstaq.ZZSwapGate(sympy.var("θ"))
     cirq.testing.assert_consistent_resolve_parameters(gate)
 
     with pytest.raises(TypeError, match="cirq.unitary failed. Value doesn't have"):
@@ -309,7 +309,7 @@ def test_parallel_gates_equivalence_groups() -> None:
         else:
             assert operation != gate(*permuted_qubits)
 
-    gate = cirq_superstaq.ParallelGates(cirq.X, cirq_superstaq.FermionicSWAPGate(1.23), cirq.X)
+    gate = cirq_superstaq.ParallelGates(cirq.X, cirq_superstaq.ZZSwapGate(1.23), cirq.X)
     operation = gate(*qubits[:4])
     assert [gate.qubit_index_to_equivalence_group_key(i) for i in range(4)] == [0, 1, 1, 0]
     equivalent_targets = [
@@ -436,7 +436,7 @@ def test_parallel_rgate() -> None:
 def test_custom_resolver() -> None:
     circuit = cirq.Circuit()
     qubits = cirq.LineQubit.range(4)
-    circuit += cirq_superstaq.FermionicSWAPGate(1.23).on(qubits[0], qubits[1])
+    circuit += cirq_superstaq.ZZSwapGate(1.23).on(qubits[0], qubits[1])
     circuit += cirq_superstaq.AceCRPlusMinus(qubits[0], qubits[1])
     circuit += cirq_superstaq.Barrier(2).on(qubits[0], qubits[1])
     circuit += cirq_superstaq.CR(qubits[0], qubits[1])


### PR DESCRIPTION
gate renamed to avoid conflicts w/ prior usage of "Fermionic SWAP"

parity: SupertechLabs/qiskit-superstaq#100