### PR TITLE
Edited `cq_compile` circuit

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -100,8 +100,7 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
     circuit = cirq.Circuit(
         cirq.H(qubits[0]),
         cirq.CNOT(qubits[0], qubits[1]),
-        cirq.measure(qubits[0]),
-        cirq.measure(qubits[1]),
+        cirq.measure(qubits[0], qubits[1]),
     )
     compiled_circuit = cirq.Circuit(
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -98,7 +98,10 @@ def test_qscout_compile(service: cirq_superstaq.Service) -> None:
 def test_cq_compile(service: cirq_superstaq.Service) -> None:
     qubits = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
-        cirq.H(qubits[0]), cirq.CNOT(qubits[0], qubits[1]), cirq.measure(qubits[0])
+        cirq.H(qubits[0]),
+        cirq.CNOT(qubits[0], qubits[1]),
+        cirq.measure(qubits[0]),
+        cirq.measure(qubits[1]),
     )
     compiled_circuit = cirq.Circuit(
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -106,11 +106,11 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
         cirq.Z(qubits[1]) ** -1.0,
         cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
         cirq.CZ(qubits[0], qubits[1]) ** -1.0,
+        cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
+        cirq.Z(qubits[1]) ** -1.0,
+        cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
         cirq.Z(qubits[0]),
         cirq.measure(qubits[0]),
-        cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.Z(qubits[0]) ** -1.0,
-        cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
     )
 
     out = service.cq_compile(circuit)

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -100,7 +100,7 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
     circuit = cirq.Circuit(
         cirq.H(qubits[0]),
         cirq.CNOT(qubits[0], qubits[1]),
-        cirq.measure(qubits[0], qubits[1]),
+        cirq.measure(qubits[0]),
     )
     compiled_circuit = cirq.Circuit(
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
@@ -111,7 +111,7 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
         cirq.Z(qubits[0]),
         cirq.measure(qubits[0]),
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.Z(qubits[1]) ** -1.0,
+        cirq.Z(qubits[0]) ** -1.0,
         cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
     )
 

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -98,9 +98,7 @@ def test_qscout_compile(service: cirq_superstaq.Service) -> None:
 def test_cq_compile(service: cirq_superstaq.Service) -> None:
     qubits = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
-        cirq.H(qubits[0]),
-        cirq.CNOT(qubits[0], qubits[1]),
-        cirq.measure(qubits[0]),
+        cirq.H(qubits[0]), cirq.CNOT(qubits[0], qubits[1]), cirq.measure(qubits[0])
     )
     compiled_circuit = cirq.Circuit(
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),


### PR DESCRIPTION
Fixes #173. ~Added qubit measurement on `cq_compile` test. Whoops, misread the circuit -- the problem wasn't a measurement, but the last `cirq.Z` gate in the hard-coded circuit was applied to the wrong qubit.~ The compiled circuit was a bit different. I'm not sure if this is because of recent changes to `cq_compile` or not.

![daily-integration](https://user-images.githubusercontent.com/18367737/152852864-28e8bcda-74da-4a01-ab62-09583acf18b9.png)