### PR TITLE
remove Z gate that is now annihilated by the CQDevice compiler

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -109,7 +109,6 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
         cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
         cirq.Z(qubits[1]) ** -1.0,
         cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.Z(qubits[0]),
         cirq.measure(qubits[0]),
     )
 


### PR DESCRIPTION
Fixes minor issue in [comment](https://github.com/SupertechLabs/cirq-superstaq/pull/174#issuecomment-1032257038).

Follows [superstaq:#1082](https://github.com/SupertechLabs/SuperstaQ/pull/1082).