### PR TITLE
check for qiskit in ibmq_compile

### DIFF
--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -53,6 +53,30 @@ class CompilerOutput:
         )
 
 
+def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
+    """Reads out returned JSON from SuperstaQ API's IBMQ compilation endpoint.
+
+    Args:
+        json_dict: a JSON dictionary matching the format returned by /ibmq_compile endpoint
+        circuits_is_list: bool flag that controls whether the returned object has a .circuits
+            attribute (if True) or a .circuit attribute (False)
+    Returns:
+        a CompilerOutput object with the compiled circuit(s). If qiskit is available locally,
+        the returned object also stores the pulse sequences in the .pulse_sequence(s) attribute.
+    """
+    compiled_circuits = cirq_superstaq.serialization.deserialize_circuits(
+        json_dict["cirq_circuits"]
+    )
+    pulses = None
+
+    if importlib.util.find_spec("qiskit"):
+        pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
+
+    if circuits_is_list:
+        return CompilerOutput(circuits=compiled_circuits, pulse_sequences=pulses)
+    return CompilerOutput(circuits=compiled_circuits[0], pulse_sequences=pulses and pulses[0])
+
+
 def read_json_aqt(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     """Reads out returned JSON from SuperstaQ API's AQT compilation endpoint.
 

--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -67,10 +67,16 @@ def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     compiled_circuits = cirq_superstaq.serialization.deserialize_circuits(
         json_dict["cirq_circuits"]
     )
-    pulses = None
 
     if importlib.util.find_spec("qiskit"):
+        import qiskit
+        if qiskit.__version__ < "0.18":
+            raise applications_superstaq.SuperstaQException(
+                "ibmq_compile requires Qiskit Terra version 0.18 or higher."
+            )
         pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
+    else:
+        pulses = None
 
     if circuits_is_list:
         return CompilerOutput(circuits=compiled_circuits, pulse_sequences=pulses)

--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -1,4 +1,5 @@
 import importlib
+import warnings
 from typing import Any, List, Optional, Union
 
 import applications_superstaq
@@ -67,16 +68,23 @@ def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     compiled_circuits = cirq_superstaq.serialization.deserialize_circuits(
         json_dict["cirq_circuits"]
     )
+    pulses = None
 
     if importlib.util.find_spec("qiskit"):
         import qiskit
-        if qiskit.__version__ < "0.18":
-            raise applications_superstaq.SuperstaQException(
-                "ibmq_compile requires Qiskit Terra version 0.18 or higher."
+
+        if qiskit.__version__ >= "0.18":
+            pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
+        else:
+            warnings.warn(
+                "ibmq_compile requires Qiskit Terra version 0.18.0 or higher to deserialize"
+                f"compiled pulse sequences (you have {qiskit.__version__})."
             )
-        pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
     else:
-        pulses = None
+        warnings.warn(
+            "ibmq_compile requires Qiskit Terra version 0.18.0 or higher to deserialize"
+            "compiled pulse sequences."
+        )
 
     if circuits_is_list:
         return CompilerOutput(circuits=compiled_circuits, pulse_sequences=pulses)

--- a/cirq_superstaq/compiler_output_test.py
+++ b/cirq_superstaq/compiler_output_test.py
@@ -44,16 +44,18 @@ def test_read_json_ibmq() -> None:
     assert not hasattr(out, "circuit")
     assert not hasattr(out, "pulse_sequence")
 
-    with mock.patch("qiskit.__version__", "0.17.2"), pytest.raises(
-        applications_superstaq.SuperstaQException, match="Qiskit Terra version"
+    with mock.patch.dict("sys.modules", {"qiskit": None}), pytest.warns(
+        UserWarning, match="requires Qiskit Terra"
     ):
-        _ = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
-
-    with mock.patch.dict("sys.modules", {"qiskit": None}):
         out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
+        assert out.circuit == circuit
         assert out.pulse_sequence is None
 
+    with mock.patch("qiskit.__version__", "0.17.2"), pytest.warns(
+        UserWarning, match="you have 0.17.2"
+    ):
         out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=True)
+        assert out.circuits == [circuit]
         assert out.pulse_sequences is None
 
 

--- a/cirq_superstaq/compiler_output_test.py
+++ b/cirq_superstaq/compiler_output_test.py
@@ -22,8 +22,37 @@ def test_aqt_out_repr() -> None:
     )
 
 
+def test_read_json_ibmq() -> None:
+    q0 = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
+
+    json_dict = {
+        "cirq_circuits": cirq_superstaq.serialization.serialize_circuits(circuit),
+        "pulses": applications_superstaq.converters.serialize([mock.DEFAULT]),
+    }
+
+    out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
+    assert out.circuit == circuit
+    assert out.pulse_sequence == mock.DEFAULT
+    assert not hasattr(out, "circuits")
+    assert not hasattr(out, "pulse_sequences")
+
+    out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=True)
+    assert out.circuits == [circuit]
+    assert out.pulse_sequences == [mock.DEFAULT]
+    assert not hasattr(out, "circuit")
+    assert not hasattr(out, "pulse_sequence")
+
+    with mock.patch.dict("sys.modules", {"qiskit": None}):
+        out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
+        assert out.pulse_sequence is None
+
+        out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=True)
+        assert out.pulse_sequences is None
+
+
 @mock.patch.dict("sys.modules", {"qtrl": None})
-def test_read_json() -> None:
+def test_read_json_aqt() -> None:
     importlib.reload(cirq_superstaq.compiler_output)
 
     circuit = cirq.Circuit(cirq.H(cirq.LineQubit(4)))
@@ -58,18 +87,18 @@ def test_read_json() -> None:
     assert not hasattr(out, "circuit")
 
 
-def test_read_json_with_qscout() -> None:
+def test_read_json_qscout() -> None:
     q0 = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
 
     jaqal_program = textwrap.dedent(
         """\
-                register allqubits[1]
-                prepare_all
-                R allqubits[0] -1.5707963267948966 1.5707963267948966
-                Rz allqubits[0] -3.141592653589793
-                measure_all
-                """
+        register allqubits[1]
+        prepare_all
+        R allqubits[0] -1.5707963267948966 1.5707963267948966
+        Rz allqubits[0] -3.141592653589793
+        measure_all
+        """
     )
 
     json_dict = {

--- a/cirq_superstaq/compiler_output_test.py
+++ b/cirq_superstaq/compiler_output_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import applications_superstaq
 import cirq
+import pytest
 
 import cirq_superstaq
 
@@ -42,6 +43,11 @@ def test_read_json_ibmq() -> None:
     assert out.pulse_sequences == [mock.DEFAULT]
     assert not hasattr(out, "circuit")
     assert not hasattr(out, "pulse_sequence")
+
+    with mock.patch("qiskit.__version__", "0.17.2"), pytest.raises(
+        applications_superstaq.SuperstaQException, match="Qiskit Terra version"
+    ):
+        _ = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)
 
     with mock.patch.dict("sys.modules", {"qiskit": None}):
         out = cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list=False)

--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -334,33 +334,20 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
     ) -> Any:
         """Returns pulse schedule for the given circuit and target.
 
-        Qiskit must be installed for returned object to correctly deserialize to a pulse schedule.
+        Qiskit Terra must be installed to correctly deserialize the returned pulse schedule.
         """
         serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)
+        circuits_is_list = not isinstance(circuits, cirq.Circuit)
 
         json_dict = self._client.ibmq_compile(
             {"cirq_circuits": serialized_circuits, "backend": target}
         )
-        try:
-            compiled_circuits = cirq_superstaq.serialization.deserialize_circuits(
-                json_dict["cirq_circuits"]
-            )
-            pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
-        except ModuleNotFoundError as e:
-            raise applications_superstaq.SuperstaQModuleNotFoundException(
-                name=str(e.name), context="ibmq_compile"
-            )
-        if isinstance(circuits, cirq.Circuit):
-            return cirq_superstaq.compiler_output.CompilerOutput(
-                circuits=compiled_circuits[0], pulse_sequences=pulses[0]
-            )
-        return cirq_superstaq.compiler_output.CompilerOutput(
-            circuits=compiled_circuits, pulse_sequences=pulses
-        )
+
+        return cirq_superstaq.compiler_output.read_json_ibmq(json_dict, circuits_is_list)
 
     def neutral_atom_compile(
         self, circuits: Union[cirq.Circuit, List[cirq.Circuit]], target: str = "neutral_atom_qpu"
-    ) -> Any:
+    ) -> cirq_superstaq.compiler_output.CompilerOutput:
         """Returns pulse schedule for the given circuit and target.
 
         Pulse must be installed for returned object to correctly deserialize to a pulse schedule.

--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -347,7 +347,7 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
 
     def neutral_atom_compile(
         self, circuits: Union[cirq.Circuit, List[cirq.Circuit]], target: str = "neutral_atom_qpu"
-    ) -> cirq_superstaq.compiler_output.CompilerOutput:
+    ) -> Any:
         """Returns pulse schedule for the given circuit and target.
 
         Pulse must be installed for returned object to correctly deserialize to a pulse schedule.

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -299,11 +299,9 @@ def test_service_ibmq_compile(mock_ibmq_compile: mock.MagicMock) -> None:
     assert service.ibmq_compile(circuit).pulse_sequence == mock.DEFAULT
     assert service.ibmq_compile([circuit]).pulse_sequences == [mock.DEFAULT]
 
-    with mock.patch.dict("sys.modules", {"unittest": None}), pytest.raises(
-        applications_superstaq.SuperstaQModuleNotFoundException,
-        match="'ibmq_compile' requires module 'unittest'",
-    ):
-        _ = service.ibmq_compile(cirq.Circuit())
+    with mock.patch.dict("sys.modules", {"qiskit": None}):
+        assert service.ibmq_compile(cirq.Circuit()).pulse_sequence is None
+        assert service.ibmq_compile([cirq.Circuit()]).pulse_sequences is None
 
 
 @mock.patch(


### PR DESCRIPTION
related to #51, but now that `ibmq_compile` returns both pulse schedules and compiled circuits we can throw a warning but still return the circuits when qiskit isn't installed

also fixes: #200