### PR TITLE
support singular `CompilerOutput.jaqal_program`

### DIFF
--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -19,20 +19,21 @@ class CompilerOutput:
         circuits: Union[cirq.Circuit, List[cirq.Circuit]],
         pulse_sequences: Any = None,
         seq: Optional["qtrl.sequencer.Sequence"] = None,
-        jaqal_programs: List[str] = None,
+        jaqal_programs: Optional[Union[List[str], str]] = None,
         pulse_lists: Optional[Union[List[List], List[List[List]]]] = None,
     ) -> None:
         if isinstance(circuits, cirq.Circuit):
             self.circuit = circuits
             self.pulse_list = pulse_lists
             self.pulse_sequence = pulse_sequences
+            self.jaqal_program = jaqal_programs
         else:
             self.circuits = circuits
             self.pulse_lists = pulse_lists
             self.pulse_sequences = pulse_sequences
+            self.jaqal_programs = jaqal_programs
 
         self.seq = seq
-        self.jaqal_programs = jaqal_programs
 
     def has_multiple_circuits(self) -> bool:
         """Returns True if this object represents multiple circuits.
@@ -45,12 +46,12 @@ class CompilerOutput:
     def __repr__(self) -> str:
         if not self.has_multiple_circuits():
             return (
-                f"CompilerOutput({self.circuit!r}, {self.seq!r}, {self.jaqal_programs!r}, "
-                f"{self.pulse_list!r})"
+                f"CompilerOutput({self.circuit!r}, {self.pulse_sequence!r}, {self.seq!r}, "
+                f"{self.jaqal_program!r}, {self.pulse_list!r})"
             )
         return (
-            f"CompilerOutput({self.circuits!r}, {self.seq!r}, {self.jaqal_programs!r}, "
-            f"{self.pulse_lists!r})"
+            f"CompilerOutput({self.circuits!r}, {self.pulse_sequences!r}, {self.seq!r}, "
+            f"{self.jaqal_programs!r}, {self.pulse_lists!r})"
         )
 
 
@@ -161,8 +162,7 @@ def read_json_only_circuits(json_dict: dict, circuits_is_list: bool) -> Compiler
         circuits_is_list: bool flag that controls whether the returned object has a .circuits
             attribute (if True) or a .circuit attribute (False)
     Returns:
-        a CompilerOutput object with the compiled circuit(s) and a list jaqal programs
-        represented as strings
+        a CompilerOutput object with the compiled circuit(s)
     """
 
     compiled_circuits = cirq_superstaq.serialization.deserialize_circuits(

--- a/cirq_superstaq/compiler_output_test.py
+++ b/cirq_superstaq/compiler_output_test.py
@@ -9,17 +9,17 @@ import pytest
 import cirq_superstaq
 
 
-def test_aqt_out_repr() -> None:
+def test_compiler_output_repr() -> None:
     circuit = cirq.Circuit()
     assert (
         repr(cirq_superstaq.compiler_output.CompilerOutput(circuit))
-        == f"CompilerOutput({circuit!r}, None, None, None)"
+        == f"CompilerOutput({circuit!r}, None, None, None, None)"
     )
 
     circuits = [circuit, circuit]
     assert (
         repr(cirq_superstaq.compiler_output.CompilerOutput(circuits))
-        == f"CompilerOutput({circuits!r}, None, None, None)"
+        == f"CompilerOutput({circuits!r}, None, None, None, None)"
     )
 
 
@@ -116,7 +116,8 @@ def test_read_json_qscout() -> None:
 
     out = cirq_superstaq.compiler_output.read_json_qscout(json_dict, circuits_is_list=False)
     assert out.circuit == circuit
-    assert out.jaqal_programs == jaqal_program
+    assert out.jaqal_program == jaqal_program
+    assert not hasattr(out, "jaqal_programs")
 
     json_dict = {
         "cirq_circuits": cirq_superstaq.serialization.serialize_circuits([circuit, circuit]),
@@ -125,6 +126,7 @@ def test_read_json_qscout() -> None:
     out = cirq_superstaq.compiler_output.read_json_qscout(json_dict, circuits_is_list=True)
     assert out.circuits == [circuit, circuit]
     assert out.jaqal_programs == json_dict["jaqal_programs"]
+    assert not hasattr(out, "jaqal_program")
 
 
 def test_read_json_only_circuits() -> None:

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -98,17 +98,17 @@ def test_qscout_compile(service: cirq_superstaq.Service) -> None:
 
     jaqal_program = textwrap.dedent(
         """\
-                register allqubits[1]
+        register allqubits[1]
 
-                prepare_all
-                R allqubits[0] -1.5707963267948966 1.5707963267948966
-                Rz allqubits[0] -3.141592653589793
-                measure_all
-                """
+        prepare_all
+        R allqubits[0] -1.5707963267948966 1.5707963267948966
+        Rz allqubits[0] -3.141592653589793
+        measure_all
+        """
     )
     out = service.qscout_compile(circuit)
     assert out.circuit == compiled_circuit
-    assert out.jaqal_programs == jaqal_program
+    assert out.jaqal_program == jaqal_program
 
 
 def test_cq_compile(service: cirq_superstaq.Service) -> None:

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -245,12 +245,12 @@ def test_service_qscout_compile_single(mock_qscout_compile: mock.MagicMock) -> N
 
     jaqal_program = textwrap.dedent(
         """\
-                register allqubits[1]
-                prepare_all
-                R allqubits[0] -1.5707963267948966 1.5707963267948966
-                Rz allqubits[0] -3.141592653589793
-                measure_all
-                """
+        register allqubits[1]
+        prepare_all
+        R allqubits[0] -1.5707963267948966 1.5707963267948966
+        Rz allqubits[0] -3.141592653589793
+        measure_all
+        """
     )
 
     mock_qscout_compile.return_value = {
@@ -261,7 +261,7 @@ def test_service_qscout_compile_single(mock_qscout_compile: mock.MagicMock) -> N
     service = cirq_superstaq.Service(remote_host="http://example.com", api_key="key")
     out = service.qscout_compile(circuit)
     assert out.circuit == circuit
-    assert out.jaqal_programs == jaqal_program
+    assert out.jaqal_program == jaqal_program
 
 
 @mock.patch("applications_superstaq.superstaq_client._SuperstaQClient.cq_compile")

--- a/examples/qscout_compile.ipynb
+++ b/examples/qscout_compile.ipynb
@@ -140,7 +140,7 @@
     }
    ],
    "source": [
-    "print(compiler_output.jaqal_programs)"
+    "print(compiler_output.jaqal_program)"
    ]
   },
   {


### PR DESCRIPTION
aligns plurality of `CompilerOutput.jaqal_program(s)` with that of `.circuit(s)` (in line with `qiskit_superstaq.CompilerOutput`)

also corrects `CompulerOutput.__repr__`, however this could definitely use an overhaul (see #103)