### PR TITLE
prevent cirq optimizations from crossing barriers

### DIFF
--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -284,6 +284,9 @@ class Barrier(cirq.ops.IdentityGate):
     def _decompose_(self, qubits: Sequence["cirq.Qid"]) -> cirq.type_workarounds.NotImplementedType:
         return NotImplemented
 
+    def _trace_distance_bound_(self):
+        return 1.0
+
     def _qasm_(self, args: cirq.QasmArgs, qubits: Tuple[cirq.Qid, ...]) -> str:
         indices_str = ",".join([f"{{{i}}}" for i in range(len(qubits))])
         format_str = f"barrier {indices_str};\n"

--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -284,7 +284,7 @@ class Barrier(cirq.ops.IdentityGate):
     def _decompose_(self, qubits: Sequence["cirq.Qid"]) -> cirq.type_workarounds.NotImplementedType:
         return NotImplemented
 
-    def _trace_distance_bound_(self):
+    def _trace_distance_bound_(self) -> float:
         return 1.0
 
     def _qasm_(self, args: cirq.QasmArgs, qubits: Tuple[cirq.Qid, ...]) -> str:

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -303,6 +303,11 @@ def test_barrier() -> None:
         use_unicode_characters=False,
     )
 
+    # make sure optimizations don't drop Barriers:
+    cirq.DropNegligible()(circuit)
+    assert circuit == cirq.Circuit(operation)
+    assert cirq.trace_distance_bound(gate) == 1.0
+
 
 def test_parallel_gates() -> None:
     gate = cirq_superstaq.ParallelGates(cirq.CZ, cirq.CZ**0.5, cirq.CZ**-0.5)


### PR DESCRIPTION
adds `Barrier._trace_distance_bound_()`, which prevents `Barrier` ops from getting dropped by optimization functions like `cirq.DropNegligible()`