### PR TITLE
`save_configs` renamed to `download_configs`

### DIFF
--- a/examples/aqt_compile.ipynb
+++ b/examples/aqt_compile.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "service.aqt_save_configs(\"Pulses.yaml\", \"Variables.yaml\")"
+    "service.aqt_download_configs(\"Pulses.yaml\", \"Variables.yaml\")"
    ]
   },
   {


### PR DESCRIPTION
Renamed for consistency with `download_configs`. (Needs https://github.com/SupertechLabs/applications-superstaq/pull/53)