### PR TITLE
Patch removal of `device` attribute from `cirq.Circuit()`

### DIFF
--- a/cirq_superstaq/serialization.py
+++ b/cirq_superstaq/serialization.py
@@ -1,6 +1,7 @@
 from typing import List, Sequence, Union
 
 import cirq
+import json
 
 import cirq_superstaq
 
@@ -16,7 +17,16 @@ def serialize_circuits(
     Returns:
         str representing the serialized circuit(s)
     """
-    return cirq.to_json(circuits)
+    dt = json.loads(cirq.to_json(circuits))
+    if isinstance(dt, list):
+        for circuit_dt in dt:
+            if 'device' not in circuit_dt:
+                circuit_dt['device'] = {'cirq_type': '_UnconstrainedDevice'}
+    else:
+        if 'device' not in dt:
+            dt['device'] = {'cirq_type': '_UnconstrainedDevice'}
+
+    return json.dumps(dt)
 
 
 def deserialize_circuits(serialized_circuits: str) -> List[cirq.Circuit]:

--- a/cirq_superstaq/serialization.py
+++ b/cirq_superstaq/serialization.py
@@ -1,7 +1,7 @@
+import json
 from typing import List, Sequence, Union
 
 import cirq
-import json
 
 import cirq_superstaq
 
@@ -20,11 +20,11 @@ def serialize_circuits(
     dt = json.loads(cirq.to_json(circuits))
     if isinstance(dt, list):
         for circuit_dt in dt:
-            if 'device' not in circuit_dt:
-                circuit_dt['device'] = {'cirq_type': '_UnconstrainedDevice'}
+            if "device" not in circuit_dt:
+                circuit_dt["device"] = {"cirq_type": "_UnconstrainedDevice"}
     else:
-        if 'device' not in dt:
-            dt['device'] = {'cirq_type': '_UnconstrainedDevice'}
+        if "device" not in dt:
+            dt["device"] = {"cirq_type": "_UnconstrainedDevice"}
 
     return json.dumps(dt)
 

--- a/cirq_superstaq/serialization_test.py
+++ b/cirq_superstaq/serialization_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import cirq
 
 import cirq_superstaq.serialization
@@ -12,6 +14,26 @@ def test_serialization() -> None:
     assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == [circuit]
 
     circuits = [circuit, circuit]
+    serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)
+    assert isinstance(serialized_circuits, str)
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuits) == circuits
+
+
+@mock.patch("cirq.to_json")
+def test_removed_device_circuit_atrribute(mock_cirq_to_json: mock.MagicMock) -> None:
+    mock_cirq_to_json.return_value = '{\n  "cirq_type": "Circuit",\n  "moments": []\n}'
+
+    circuit = cirq.Circuit()
+
+    serialized_circuit = cirq_superstaq.serialization.serialize_circuits(circuit)
+    assert isinstance(serialized_circuit, str)
+    assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuit) == [circuit]
+
+    circuits = [circuit, circuit]
+    mock_cirq_to_json.return_value = (
+        '[\n  {\n    "cirq_type": "Circuit",\n    "moments": []\n  },\n  {\n    '
+        '"cirq_type": "Circuit",\n    "moments": []\n  }\n]'
+    )
     serialized_circuits = cirq_superstaq.serialization.serialize_circuits(circuits)
     assert isinstance(serialized_circuits, str)
     assert cirq_superstaq.serialization.deserialize_circuits(serialized_circuits) == circuits

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 applications-superstaq>=0.1.5
-cirq>=0.13.0,<=0.15.0.dev20220420201205
+cirq>=0.13.0
 qubovert>=1.2.3
 sympy<1.10


### PR DESCRIPTION
This PR gets around https://github.com/quantumlib/Cirq/pull/5189; which is a breaking change.