### PR TITLE
Use `cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent` for circuit comparison in `daily_integration_test.py`

### DIFF
--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -46,31 +46,24 @@ def test_acer_non_neighbor_qubits_compile(service: cirq_superstaq.Service) -> No
 def test_aqt_compile(service: cirq_superstaq.Service) -> None:
     qubits = cirq.LineQubit.range(8)
     circuit = cirq.Circuit(cirq.H(qubits[4]))
-    expected = cirq.Circuit(
-        cirq.rz(np.pi / 2)(qubits[4]),
-        cirq.rx(np.pi / 2)(qubits[4]),
-        cirq.rz(np.pi / 2)(qubits[4]),
-    )
 
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-        service.aqt_compile(circuit).circuit, expected, atol=1e-08
+        service.aqt_compile(circuit).circuit, circuit, atol=1e-08
     )
 
     compiled_circuits = service.aqt_compile([circuit]).circuits
     assert isinstance(compiled_circuits, list)
     for compiled_circuit in compiled_circuits:
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-            compiled_circuit, expected, atol=1e-08
+            compiled_circuit, circuit, atol=1e-08
         )
     compiled_circuits = service.aqt_compile([circuit, circuit]).circuits
 
     assert isinstance(compiled_circuits, list)
     for compiled_circuit in compiled_circuits:
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-            compiled_circuit, expected, atol=1e-08
+            compiled_circuit, circuit, atol=1e-08
         )
-
-    assert service.aqt_compile([circuit, circuit]).circuits == [expected, expected]
 
 
 def test_get_balance(service: cirq_superstaq.Service) -> None:

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -51,8 +51,25 @@ def test_aqt_compile(service: cirq_superstaq.Service) -> None:
         cirq.rx(np.pi / 2)(qubits[4]),
         cirq.rz(np.pi / 2)(qubits[4]),
     )
-    assert service.aqt_compile(circuit).circuit == expected
-    assert service.aqt_compile([circuit]).circuits == [expected]
+
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        service.aqt_compile(circuit).circuit, expected, atol=1e-08
+    )
+
+    compiled_circuits = service.aqt_compile([circuit]).circuits
+    assert isinstance(compiled_circuits, list)
+    for compiled_circuit in compiled_circuits:
+        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+            compiled_circuit, expected, atol=1e-08
+        )
+    compiled_circuits = service.aqt_compile([circuit, circuit]).circuits
+
+    assert isinstance(compiled_circuits, list)
+    for compiled_circuit in compiled_circuits:
+        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+            compiled_circuit, expected, atol=1e-08
+        )
+
     assert service.aqt_compile([circuit, circuit]).circuits == [expected, expected]
 
 
@@ -107,7 +124,9 @@ def test_qscout_compile(service: cirq_superstaq.Service) -> None:
         """
     )
     out = service.qscout_compile(circuit)
-    assert out.circuit == compiled_circuit
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        out.circuit, compiled_circuit, atol=1e-08
+    )
     assert out.jaqal_program == jaqal_program
 
 
@@ -129,7 +148,9 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
     )
 
     out = service.cq_compile(circuit)
-    assert out.circuit == compiled_circuit
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        out.circuit, compiled_circuit, atol=1e-08
+    )
 
 
 def test_get_aqt_configs(service: cirq_superstaq.Service) -> None:

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -142,7 +142,7 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
 
     out = service.cq_compile(circuit)
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-        out.circuit, compiled_circuit, atol=1e-08
+        out.circuit, circuit, atol=1e-08
     )
 
 

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -4,7 +4,6 @@ import os
 import textwrap
 
 import cirq
-import numpy as np
 import pytest
 from applications_superstaq import SuperstaQException
 

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -128,17 +128,6 @@ def test_cq_compile(service: cirq_superstaq.Service) -> None:
     circuit = cirq.Circuit(
         cirq.H(qubits[0]), cirq.CNOT(qubits[0], qubits[1]), cirq.measure(qubits[0])
     )
-    compiled_circuit = cirq.Circuit(
-        cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.Z(qubits[0]) ** -1.0,
-        cirq.Z(qubits[1]) ** -1.0,
-        cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.CZ(qubits[0], qubits[1]) ** -1.0,
-        cirq_superstaq.ParallelRGate(-0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.Z(qubits[1]) ** -1.0,
-        cirq_superstaq.ParallelRGate(0.25 * np.pi, 0.5 * np.pi, 2).on(qubits[0], qubits[1]),
-        cirq.measure(qubits[0]),
-    )
 
     out = service.cq_compile(circuit)
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(


### PR DESCRIPTION
Fixes https://github.com/SupertechLabs/cirq-superstaq/issues/243