### PR TITLE
Added cirq_to_qiskit conversion function to Service

### DIFF
--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -401,3 +401,14 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
         if isinstance(circuits, cirq.Circuit):
             return pulses[0]
         return pulses
+
+    def cirq_to_qiskit(
+        self,
+        cirq_circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+    ) -> str:
+        """Converts the given `cirq.Circuit`s to (serialized) `qiskit.QuantumCircuit`s."""
+        serialized_circuits = css.serialization.serialize_circuits(cirq_circuits)
+
+        json_dict = self._client.cirq_to_qiskit({"cirq_circuits": serialized_circuits})
+
+        return json_dict["qiskit_circuits"]

--- a/cirq_superstaq/service_test.py
+++ b/cirq_superstaq/service_test.py
@@ -206,6 +206,22 @@ def test_service_get_backends() -> None:
 
 
 @mock.patch(
+    "applications_superstaq.superstaq_client._SuperstaQClient.cirq_to_qiskit",
+)
+def test_service_cirq_to_qiskit(mock_cirq_to_qiskit: mock.MagicMock) -> None:
+    service = css.Service(remote_host="http://example.com", api_key="key")
+
+    q0 = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
+
+    mock_cirq_to_qiskit.return_value = {
+        "qiskit_circuits": "SerializedQuantumCircuit",
+    }
+
+    assert isinstance(service.cirq_to_qiskit(circuit), str)
+
+
+@mock.patch(
     "applications_superstaq.superstaq_client._SuperstaQClient.aqt_compile",
     return_value={
         "cirq_circuits": css.serialization.serialize_circuits(cirq.Circuit()),


### PR DESCRIPTION
Currently the function returns the _serialized_ `qiskit.QuantumCircuits` -- this is to avoid needing to import qiskit and qiskit-superstaq within cirq-superstaq. The deserialization can be done within SupermarQ.