### PR TITLE
update qiskit version check

### DIFF
--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Union
 
 import applications_superstaq
 import cirq
+import packaging.version
 
 import cirq_superstaq as css
 
@@ -72,7 +73,7 @@ def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     if importlib.util.find_spec("qiskit"):
         import qiskit
 
-        if qiskit.__version__ >= "0.20":
+        if packaging.version.parse(qiskit.__version__) >= packaging.version.parse("0.20.0"):
             pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
         else:
             warnings.warn(

--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -4,7 +4,6 @@ from typing import Any, List, Optional, Union
 
 import applications_superstaq
 import cirq
-import packaging.version
 
 import cirq_superstaq as css
 
@@ -73,17 +72,17 @@ def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     if importlib.util.find_spec("qiskit"):
         import qiskit
 
-        if packaging.version.parse(qiskit.__version__) >= packaging.version.parse("0.20.0"):
+        if "0.20" < qiskit.__version__ < "0.21":
             pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
         else:
             warnings.warn(
-                "ibmq_compile requires Qiskit Terra version 0.20.0 or higher to deserialize"
-                f"compiled pulse sequences (you have {qiskit.__version__})."
+                "ibmq_compile requires Qiskit Terra version 0.20.* to deserialize compiled pulse "
+                f"sequences (you have {qiskit.__version__})."
             )
     else:
         warnings.warn(
-            "ibmq_compile requires Qiskit Terra version 0.20.0 or higher to deserialize"
-            "compiled pulse sequences."
+            "ibmq_compile requires Qiskit Terra version 0.20.* to deserialize compiled pulse "
+            "sequences."
         )
 
     if circuits_is_list:

--- a/cirq_superstaq/compiler_output.py
+++ b/cirq_superstaq/compiler_output.py
@@ -72,16 +72,16 @@ def read_json_ibmq(json_dict: dict, circuits_is_list: bool) -> CompilerOutput:
     if importlib.util.find_spec("qiskit"):
         import qiskit
 
-        if qiskit.__version__ >= "0.18":
+        if qiskit.__version__ >= "0.20":
             pulses = applications_superstaq.converters.deserialize(json_dict["pulses"])
         else:
             warnings.warn(
-                "ibmq_compile requires Qiskit Terra version 0.18.0 or higher to deserialize"
+                "ibmq_compile requires Qiskit Terra version 0.20.0 or higher to deserialize"
                 f"compiled pulse sequences (you have {qiskit.__version__})."
             )
     else:
         warnings.warn(
-            "ibmq_compile requires Qiskit Terra version 0.18.0 or higher to deserialize"
+            "ibmq_compile requires Qiskit Terra version 0.20.0 or higher to deserialize"
             "compiled pulse sequences."
         )
 

--- a/cirq_superstaq/service.py
+++ b/cirq_superstaq/service.py
@@ -206,7 +206,7 @@ class Service(finance.Finance, logistics.Logistics, user_config.UserConfig):
 
         Args:
             circuit: The circuit to run.
-            repetitions: The number of times to repeat the circuit. Defaults to 100.
+            repetitions: The number of times to repeat the circuit. Defaults to 1000.
             target: Where to run the job. Can be 'qpu' or 'simulator'.
             ibmq_pulse: Specify whether to run the job using SuperstaQ's pulse-level optimizations.
 

--- a/examples/ibmq_compile.ipynb
+++ b/examples/ibmq_compile.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "if install_qiskit:\n",
     "    print(\"installing qiskit...\")\n",
-    "    !pip install -q qiskit-terra~=0.36.2\n",
+    "    !pip install -q qiskit-terra~=0.20.2\n",
     "    print(\"installed qiskit.\")"
    ]
   },

--- a/examples/ibmq_compile.ipynb
+++ b/examples/ibmq_compile.ipynb
@@ -22,7 +22,7 @@
     "try:\n",
     "    import qiskit\n",
     "\n",
-    "    install_qiskit = not (\"0.18\" <= qiskit.__version__ < \"0.19\")\n",
+    "    install_qiskit = not (\"0.20\" < qiskit.__version__ < \"0.21\")\n",
     "except ImportError:\n",
     "    install_qiskit = True\n",
     "\n",

--- a/examples/ibmq_compile.ipynb
+++ b/examples/ibmq_compile.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "if install_qiskit:\n",
     "    print(\"installing qiskit...\")\n",
-    "    !pip install -q qiskit-terra==0.18.3\n",
+    "    !pip install -q qiskit-terra~=0.36.2\n",
     "    print(\"installed qiskit.\")"
    ]
   },


### PR DESCRIPTION
we now require qiskit-terra >= 0.20.0 for ibmq pulse sequences


(also corrects a docstring)