### PR TITLE
fix MSGate deserialization

### DIFF
--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -575,6 +575,8 @@ def custom_resolver(cirq_type: str) -> Union[Callable[..., cirq.Gate], None]:
         return AceCR
     if cirq_type == "ParallelGates":
         return ParallelGates
+    if cirq_type == "MSGate":
+        return cirq.ops.MSGate
     if cirq_type == "RGate":
         return RGate
     if cirq_type == "IXGate":

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -595,6 +595,7 @@ def test_custom_resolver() -> None:
     circuit += css.AceCRMinusPlus(qubits[0], qubits[1])
     circuit += css.AceCR("+-", -np.pi / 2)(qubits[0], qubits[1])
     circuit += css.ParallelGates(cirq.X, css.ZX).on(qubits[0], qubits[2], qubits[3])
+    circuit += cirq.ms(1.23).on(qubits[0], qubits[1])
     circuit += css.RGate(1.23, 4.56).on(qubits[0])
     circuit += css.ParallelRGate(1.23, 4.56, len(qubits)).on(*qubits)
     circuit += css.AQTITOFFOLI(qubits[0], qubits[1], qubits[2])

--- a/cirq_superstaq/daily_integration_test.py
+++ b/cirq_superstaq/daily_integration_test.py
@@ -99,7 +99,7 @@ def test_get_backends(service: css.Service) -> None:
 
 
 def test_qscout_compile(service: css.Service) -> None:
-    q0 = cirq.LineQubit(0)
+    q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
     compiled_circuit = cirq.Circuit(
         cirq.PhasedXPowGate(phase_exponent=-0.5, exponent=0.5).on(q0),
@@ -122,6 +122,15 @@ def test_qscout_compile(service: css.Service) -> None:
         out.circuit, compiled_circuit, atol=1e-08
     )
     assert out.jaqal_program == jaqal_program
+
+    cx_circuit = cirq.Circuit(cirq.H(q0), cirq.CX(q0, q1), cirq.measure(q0, q1))
+    out = service.qscout_compile([cx_circuit])
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        out.circuits[0], cx_circuit, atol=1e-08
+    )
+    assert isinstance(out.jaqal_programs, list)
+    assert isinstance(out.jaqal_programs[0], str)
+    assert "MS allqubits[0] allqubits[1]" in out.jaqal_programs[0]
 
 
 def test_cq_compile(service: css.Service) -> None:

--- a/cirq_superstaq/serialization_test.py
+++ b/cirq_superstaq/serialization_test.py
@@ -7,7 +7,7 @@ import cirq_superstaq as css
 
 def test_serialization() -> None:
     qubits = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit(cirq.CX(*qubits), css.ZX(*qubits))
+    circuit = cirq.Circuit(cirq.CX(*qubits), css.ZX(*qubits), cirq.ms(1.23).on(*qubits))
 
     serialized_circuit = css.serialization.serialize_circuits(circuit)
     assert isinstance(serialized_circuit, str)


### PR DESCRIPTION
`cirq.MSGate` is not included in `cirq.DEFAULT_RESOLVERS` ([cf.](https://github.com/quantumlib/Cirq/blob/f904a09031b102a3ad5d7b55eff2c8efe565197f/cirq-core/cirq/ops/parity_gates_test.py#L303), as noticed by @vtomole), so reverts [this change](https://github.com/SupertechLabs/cirq-superstaq/pull/282/files#r915085515) and adds corresponding checks to custom_gates_test.py, serialization_test.py, and daily_integration_test.py