### PR TITLE
upper bound python-rapidjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 applications-superstaq==0.1.10
 cirq>=0.14.0
+python-rapidjson<=1.6
 qubovert>=1.2.3
 sympy<1.10


### PR DESCRIPTION
otherwise macos check fails due to https://github.com/python-rapidjson/python-rapidjson/issues/166

should be reverted once `python-rapidjson` has been patched