### PR TITLE
Changing barrier qubit input from list to unpacked tuple

### DIFF
--- a/cirq_superstaq/custom_gates.py
+++ b/cirq_superstaq/custom_gates.py
@@ -302,7 +302,7 @@ class Barrier(cirq.ops.IdentityGate):
         return ("|",) * self.num_qubits()
 
 
-def barrier(qubits: Sequence[cirq.Qid]) -> cirq.Operation:
+def barrier(*qubits: cirq.Qid) -> cirq.Operation:
     return css.Barrier(len(qubits)).on(*qubits)
 
 

--- a/cirq_superstaq/custom_gates_test.py
+++ b/cirq_superstaq/custom_gates_test.py
@@ -306,8 +306,8 @@ def test_barrier() -> None:
     assert cirq.trace_distance_bound(gate) == 1.0
 
     qubits = cirq.LineQubit.range(n)
-    barrier = css.barrier(qubits)
-    assert barrier == css.Barrier(n).on(*cirq.LineQubit.range(n))
+    barrier = css.barrier(*qubits)
+    assert barrier == css.Barrier(n).on(*qubits)
 
 
 def test_parallel_gates() -> None:


### PR DESCRIPTION
This makes the `css.barrier()` call symmetric to `cirq.measure()`